### PR TITLE
Setup Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.env
 .idea
 *.iml
+
+postgres/
+postgres_data/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "mozilla": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603906276,
+        "narHash": "sha256-RsNPnEKd7BcogwkqhaV5kI/HuNC4flH/OQCC/4W5y/8=",
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "8c007b60731c07dd7a052cce508de3bb1ae849b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1610720724,
+        "narHash": "sha256-plSXE0DbKAu+JvyQWoyYubBSY8l5h9IAsXC83E6tEW0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "95e1ba302d0927ca05566d39be9e27532c346ba8",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "mozilla": "mozilla",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "WartID: the WartaPoirier authentication and authorization service";
+
+  inputs.mozilla = { url = "github:mozilla/nixpkgs-mozilla"; flake = false; };
+
+  outputs = { self, nixpkgs, mozilla }:
+    let
+      rustOverlay = final: prev:
+        let rustChannel = prev.rustChannelOf {
+          rustToolchain = ./rust-toolchain;
+          sha256 = "sha256-uoGBMgGmIPj4E+jCY8XH41Ia8NbaRjDC3KioiaCA/M8=";
+        };
+        in {
+          inherit rustChannel;
+          rustc = rustChannel.rust;
+          cargo = rustChannel.rust;
+        };
+    in 
+    with import nixpkgs {
+      system = "x86_64-linux"; # TODO: build for other systems too
+      overlays = [
+        (import "${mozilla}/rust-overlay.nix")
+        rustOverlay
+      ];
+    };
+    {
+
+      # Discord bot
+      packages.x86_64-linux.wartid-server-discord-bot =
+        pkgs.buildRustCrate {
+          crateName = "wartid-server-discord-bot";
+          pname = "wartid-server-discord-bot";
+          version = "0.1.0";
+          src = ./.;
+          workspace_member = ./wartid-server-discord-bot;
+          cargoSha256 = lib.fakeSha256;
+          meta = with lib; {
+            description = "Discord bot WartID authentication";
+            homepage = "https://github.com/WartaPoirier-corp/WartID/";
+            license = licenses.agpl3;
+          };
+        };
+
+      defaultPackage.x86_64-linux = self.packages.x86_64-linux.wartid-server-discord-bot;
+      devShell.x86_64-linux = pkgs.mkShell {
+        name = "wartid";
+        buildInputs = with pkgs; [ rustChannel.rust diesel-cli postgresql ];
+        shellHook = ''
+            export PGDATA=$PWD/postgres_data
+            export PGHOST=$PWD/postgres
+            export LOG_PATH=$PWD/postgres/LOG
+            export PGDATABASE=wartid
+            export DATABASE_URL="postgresql:///wartid?host=$PGHOST"
+            if [ ! -d $PGHOST ]; then
+              mkdir -p $PGHOST
+            fi
+            if [ ! -d $PGDATA ]; then
+              echo 'Initializing postgresql database...'
+              initdb $PGDATA --auth=trust >/dev/null
+              pg_ctl start -l $LOG_PATH -o "-c listen_addresses= -k $PGHOST"
+              createuser -d wartid
+              createdb -O wartid wartid
+            else
+              pg_ctl start -l $LOG_PATH -o "-c listen_addresses= -k $PGHOST"
+            fi
+        '';
+      };
+    };
+}

--- a/wartid-server/migrations/2020-11-30-122841_create_users/down.sql
+++ b/wartid-server/migrations/2020-11-30-122841_create_users/down.sql
@@ -1,3 +1,4 @@
 drop index idx_users_username;
 drop index idx_users_discord;
 drop table users;
+drop extension "uuid-ossp";

--- a/wartid-server/migrations/2020-11-30-122841_create_users/up.sql
+++ b/wartid-server/migrations/2020-11-30-122841_create_users/up.sql
@@ -1,3 +1,5 @@
+create extension if not exists "uuid-ossp";
+
 create table users (
     id uuid primary key default uuid_generate_v4 (),
     username varchar(64) not null unique,

--- a/wartid-server/src/utils/jwt.rs
+++ b/wartid-server/src/utils/jwt.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::*;
-use serde::export::PhantomData;
+use std::marker::PhantomData;
 use serde::{de::DeserializeOwned, Serialize};
 
 #[cfg(test)]


### PR DESCRIPTION
- Use flakes to provide both a development shell and a way to build derivations of the binaries
  - For the moment it only provides a derivation for the bot, and only on x86 Linux
  - The development shell setups PostgreSQL too
    - It required to fix the first migration, because the Nix version of Postgres doesn't enable
      some extensions by default
- This does not integrates WartID with NixOS, it only introduces files to reproductibly build
  and develop WartID, using Nix

To use it, in case anyone else is interested

- make sure you have flakes enabled: https://nixos.wiki/wiki/Flakes
- run `nix develop`
- you are in a shell with PostgreSQL running in the background, Rust nigthly, and diesel CLI